### PR TITLE
Remove `shrink-to-fit=no`

### DIFF
--- a/src/static/templates/admin/base.hbs
+++ b/src/static/templates/admin/base.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex,nofollow" />
     <link rel="icon" type="image/png" href="{{urlpath}}/vw_static/vaultwarden-favicon.png">
     <title>Vaultwarden Admin Panel</title>


### PR DESCRIPTION
This was a workaroud needed for iOS versions before 9.3 and is not part of the recommended viewport meta tag anymore. https://www.scottohara.me/blog/2018/12/11/shrink-to-fit.html